### PR TITLE
feat: show ghost_text (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ return {
 
             score_offset = -3,
 
+            ---@module 'blink_luasnip'
+            ---@type blink_luasnip.Options
             opts = {
                 use_show_condition = false, -- disables filtering completion candidates
                 show_autosnippets = true, 
+                show_ghost_text = false,  -- whether to show a preview of the selected snippet (experimental)
             },
         },
       },


### PR DESCRIPTION
Add a new option to enable ghost text when selecting a luasnip item.
Disabled by default.

This change fixes also the user config not taken into account and add
annotation types for the available options.
